### PR TITLE
Shorten user-facing error messages

### DIFF
--- a/functions/common.py
+++ b/functions/common.py
@@ -16,11 +16,11 @@ def factorial(argument: int) -> int:
     """
     # Ensure that input is an integer.
     if int(argument) != argument:
-        raise exceptions.InputError(argument, "Input to factorial should be a non-negative integer.")
+        raise exceptions.InputError(argument, "Input to factorial must be a positive integer.")
     argument = int(argument)
     # Ensure that input is non-negative.
     if argument < 0:
-        raise exceptions.InputError(argument, "Input to factorial should be a non-negative integer.")
+        raise exceptions.InputError(argument, "Input to factorial must be a positive integer.")
 
     # Calculate factorial using repeated multiplication.
     result = 1

--- a/functions/exponents_and_logs.py
+++ b/functions/exponents_and_logs.py
@@ -57,7 +57,7 @@ def radical(radicand: float, index: int, delta: float = 1E-10) -> float:
     """
     # Ensure that real value of root exists.
     if common.is_negative(radicand) and common.is_even(index):
-        raise exceptions.InputError(None, "Radical with negative radicand and even index is undefined over set of real numbers.")
+        raise exceptions.InputError(None, "Not in domain of radical function.")
 
     # Approximate radicand using Newton's method.
     approx = 1
@@ -146,7 +146,7 @@ def pow(base: float, exponent: float, root_used: int = int(1E10)) -> float:
     fractional_part_of_exponent = exponent - integer_part_of_exponent
     # Ensure that base is not negative if exponent is not a integer.
     if common.is_negative(base) and fractional_part_of_exponent != 0:
-        raise exceptions.InputError(None, "Implementation of exponent function for real exponents does not support negative bases because the power function for negative bases is non-continuous over the set of real numbers.")
+        raise exceptions.InputError(None, "negative base with fractional exponent.")
 
     # Calculate integer part using exponentiation by squaring
     result = pow_int(float(base), integer_part_of_exponent)
@@ -203,7 +203,7 @@ def ln(argument: float) -> float:
     """
     # Ensure that argument is within domain of natural logarithm.
     if not common.is_positive(argument):
-        raise exceptions.InputError(argument, "The value of a logarithm is undefined for non-positive arguments.")
+        raise exceptions.InputError(argument, "Not in domain of log function.")
 
     # We use frexp to fetch mantissa and exponent of argument in a platform agnostic way.
     mantissa, exponent = math.frexp(argument)

--- a/functions/exponents_and_logs.py
+++ b/functions/exponents_and_logs.py
@@ -146,7 +146,7 @@ def pow(base: float, exponent: float, root_used: int = int(1E10)) -> float:
     fractional_part_of_exponent = exponent - integer_part_of_exponent
     # Ensure that base is not negative if exponent is not a integer.
     if common.is_negative(base) and fractional_part_of_exponent != 0:
-        raise exceptions.InputError(None, "negative base with fractional exponent.")
+        raise exceptions.InputError(None, "Negative base with fractional exponent.")
 
     # Calculate integer part using exponentiation by squaring
     result = pow_int(float(base), integer_part_of_exponent)

--- a/functions/output_display.py
+++ b/functions/output_display.py
@@ -122,7 +122,7 @@ def binary_to_decimal_integer(value: str) -> int:
     if value[0] == '-':
         raise exceptions.InputError(value, "binary_to_decimal_integer does not accept negative inputs.")
     if not is_binary(value):
-        raise exceptions.InputError(value, "Binary numbers can only contain 1s and 0s.")
+        raise exceptions.InputError(value, "not in binary.")
         
     the_number = str(value)
     position = 0
@@ -148,7 +148,7 @@ def binary_to_decimal_fraction(value: str) -> float:
     if value[0] == '-':
         raise exceptions.InputError(value, "binary_to_decimal_fraction does not accept negative inputs.")
     if not is_binary(value):
-        raise exceptions.InputError(value, "Binary numbers can only contain 1s and 0s.")
+        raise exceptions.InputError(value, "not in binary.")
         
     the_number = str(value)[2:]
     position = -1

--- a/functions/output_display.py
+++ b/functions/output_display.py
@@ -122,7 +122,7 @@ def binary_to_decimal_integer(value: str) -> int:
     if value[0] == '-':
         raise exceptions.InputError(value, "binary_to_decimal_integer does not accept negative inputs.")
     if not is_binary(value):
-        raise exceptions.InputError(value, "not in binary.")
+        raise exceptions.InputError(value, "Not in binary.")
         
     the_number = str(value)
     position = 0
@@ -148,7 +148,7 @@ def binary_to_decimal_fraction(value: str) -> float:
     if value[0] == '-':
         raise exceptions.InputError(value, "binary_to_decimal_fraction does not accept negative inputs.")
     if not is_binary(value):
-        raise exceptions.InputError(value, "not in binary.")
+        raise exceptions.InputError(value, "Not in binary.")
         
     the_number = str(value)[2:]
     position = -1


### PR DESCRIPTION
This is a potential solution for error messages that are too long. I edited them in-place for simplicity. If we want to keep the more descriptive messages for some reason, I could add a layer in `calculate.py` that does the substitution for user-facing messages.